### PR TITLE
Updated the method to identify classifier models

### DIFF
--- a/pytolemaic/utils/general.py
+++ b/pytolemaic/utils/general.py
@@ -13,6 +13,7 @@ import pandas
 from matplotlib._color_data import XKCD_COLORS
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
+from sklearn.base import is_classifier
 
 global tictoc
 from time import time
@@ -37,7 +38,7 @@ class GeneralUtils():
 
     @classmethod
     def is_classification(cls, model):
-        return hasattr(model, 'predict_proba')
+        return is_classifier(model)
 
     @classmethod
     def dmd_supported(cls, model, dmd):


### PR DESCRIPTION
The hasattr method is good for detecting most of the classification models but things aren't same if we are using a PyTorch regressor model wrapped with skorch as skorch has predict_proba for regressor wrapper also, so hasattr end up detecting that wrapped regressor as classifier. As pytolemaic is capable with all models that have sklearn's API references so it is a good idea to use 'is_classifier' method from sklearn base.

![image](https://user-images.githubusercontent.com/45912425/165639507-d78b23a8-c56a-419f-a227-39d12a18b66d.png)

Reference: [cell 20] https://github.com/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb